### PR TITLE
ci: update cycjimmy/semantic-release-action to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
       # https://github.com/cycjimmy/semantic-release-action
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         id: semantic
         with:
           branch: master


### PR DESCRIPTION

This PR resolves the issue of the [main](https://github.com/cypress-io/cra-template-cypress/blob/master/.github/workflows/main.yml) workflow failing since Jan 25, 2023, as seen in the [actions log](https://github.com/cypress-io/cra-template-cypress/actions/workflows/main.yml) for this workflow.

The root cause is the release of [semantic-release v20.0.0](https://github.com/semantic-release/semantic-release/releases/tag/v20.0.0) on Jan 6, 2023. The new semantic-release `v20` contains breaking changes related to ESM-only and minimum Node.js 18 and it is currently used by default by [main](https://github.com/cypress-io/cra-template-cypress/blob/master/.github/workflows/main.yml), since no version is specified.

In this PR [main](https://github.com/cypress-io/cra-template-cypress/blob/master/.github/workflows/main.yml) is updated to use [cycjimmy/semantic-release-action](https://github.com/cycjimmy/semantic-release-action) `v3` instead of `v2`.

This resolves the issue because [cycjimmy/semantic-release-action](https://github.com/cycjimmy/semantic-release-action) `v3` defaults to using the compatible [semantic-release v19.0.5](https://github.com/semantic-release/semantic-release/releases/tag/v19.0.5). The `v3` version of this action specifies a working default, whereas the previous `v2` version did not do this.

See also [cycjimmy/semantic-release-action: Semantic version](https://github.com/cycjimmy/semantic-release-action#semantic_version) documentation for current recommendations.